### PR TITLE
Fix ForcePlayerSuicide not properly working in ZPS

### DIFF
--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -516,12 +516,24 @@ static cell_t ForcePlayerSuicide(IPluginContext *pContext, const cell_t *params)
 			return pContext->ThrowNativeError("\"CommitSuicide\" wrapper failed to initialize");
 		}
 	}
-
-	START_CALL();
-	DECODE_VALVE_PARAM(1, thisinfo, 0);
-	*(bool *)(vptr + pCall->vparams[0].offset) = false;
-	*(bool *)(vptr + pCall->vparams[1].offset) = false;
-	FINISH_CALL_SIMPLE(NULL);
+#if SOURCE_ENGINE == SE_SDK2013
+	if (!strcmp(g_pSM->GetGameFolderName(), "zps"))
+	{
+		START_CALL();
+		DECODE_VALVE_PARAM(1, thisinfo, 0);
+		*(bool *)(vptr + pCall->vparams[0].offset) = false;
+		*(bool *)(vptr + pCall->vparams[1].offset) = true;
+		FINISH_CALL_SIMPLE(NULL);
+	}
+	else
+	{
+		START_CALL();
+		DECODE_VALVE_PARAM(1, thisinfo, 0);
+		*(bool *)(vptr + pCall->vparams[0].offset) = false;
+		*(bool *)(vptr + pCall->vparams[1].offset) = false;
+		FINISH_CALL_SIMPLE(NULL);
+	}
+#endif // SDK2013
 
 	return 1;
 }


### PR DESCRIPTION
ZPS requires the second bool parameter to be true otherwise it won't do anything for players in the lobby or delayed for players on either team 2 or team 3.